### PR TITLE
Introduce the internal user IDs

### DIFF
--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -33,5 +33,6 @@ func autoMigrate(db *gorm.DB) error {
 		&OrganizationUser{},
 		&Project{},
 		&ProjectUser{},
+		&User{},
 	)
 }

--- a/server/internal/store/user.go
+++ b/server/internal/store/user.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// User provides a mapping between the external user ID (= email address)
+// and the internal user ID.
+//
+// Internal UserIDs can be used to uniquely idently users without
+// exposing PII.
+type User struct {
+	gorm.Model
+
+	UserID         string `gorm:"uniqueIndex"`
+	InternalUserID string `gorm:"uniqueIndex"`
+}
+
+// FindOrCreateUserInTransaction creates a new user.
+func FindOrCreateUserInTransaction(tx *gorm.DB, userID, internalUserID string) (*User, error) {
+	var us []*User
+	if err := tx.Where("user_id = ?", userID).Find(&us).Error; err != nil {
+		return nil, err
+	}
+	if len(us) > 1 {
+		return nil, fmt.Errorf("unexpected number of users found: %v", us)
+	}
+	if len(us) == 1 {
+		return us[0], nil
+	}
+
+	u := &User{
+		UserID:         userID,
+		InternalUserID: internalUserID,
+	}
+	if err := tx.Create(u).Error; err != nil {
+		return nil, err
+	}
+	return u, nil
+}

--- a/server/internal/store/user_test.go
+++ b/server/internal/store/user_test.go
@@ -1,0 +1,22 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindOrCreateUserInTransaction(t *testing.T) {
+	st, tearDown := NewTest(t)
+	defer tearDown()
+
+	u1, err := FindOrCreateUserInTransaction(st.db, "user1", "iuser1")
+	assert.NoError(t, err)
+
+	_, err = FindOrCreateUserInTransaction(st.db, "user2", "iuser2")
+	assert.NoError(t, err)
+
+	u1Again, err := FindOrCreateUserInTransaction(st.db, "user1", "iuser1")
+	assert.NoError(t, err)
+	assert.Equal(t, u1.ID, u1Again.ID)
+}


### PR DESCRIPTION
We need more work, but we should use internal IDs to track the API usage so that we can avoid exposing PIIs.

Remaining work include:
- Change RBAC server to get the information
- Attach the internal UserID in the UserInfo