### PR TITLE
fix: fix the rendering of defaultApiKeys

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -19,8 +19,10 @@ data:
       kubernetesNamespace: {{ .Values.defaultProject.kubernetesNamespace }}
       userIds:
       {{- toYaml .Values.defaultProject.userIds | nindent 6 }}
+    {{- with .Values.defaultApiKeys }}
     defaultApiKeys:
-    {{- toYaml .Values.defaultApiKeys | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     database:
       host: {{ .Values.global.database.host }}
       port: {{ .Values.global.database.port }}


### PR DESCRIPTION
Getting an error with the following configmap:

defaultApiKeys:\n[]\ndatabase:\n