### PR TITLE
feat: add an option to hide org/project users

### DIFF
--- a/server/internal/server/org.go
+++ b/server/internal/server/org.go
@@ -293,6 +293,9 @@ func (s *S) ListOrganizationUsers(ctx context.Context, req *v1.ListOrganizationU
 
 	var userProtos []*v1.OrganizationUser
 	for _, user := range users {
+		if user.Hidden {
+			continue
+		}
 		// Do not populate the internal User ID for non-internal RPC.
 		userProtos = append(userProtos, user.ToProto(""))
 	}

--- a/server/internal/server/project.go
+++ b/server/internal/server/project.go
@@ -313,6 +313,10 @@ func (s *S) ListProjectUsers(ctx context.Context, req *v1.ListProjectUsersReques
 
 	var userProtos []*v1.ProjectUser
 	for _, user := range users {
+		if user.Hidden {
+			continue
+		}
+
 		userProtos = append(userProtos, user.ToProto())
 	}
 	return &v1.ListProjectUsersResponse{

--- a/server/internal/store/orguser.go
+++ b/server/internal/store/orguser.go
@@ -13,6 +13,9 @@ type OrganizationUser struct {
 	UserID         string `gorm:"uniqueIndex:user_id_org_id"`
 
 	Role string
+
+	// Hidden is set to true if the user is not visible from the list/get API call.
+	Hidden bool
 }
 
 // ToProto converts the model to Porto.
@@ -69,6 +72,24 @@ func (s *S) ListAllOrganizationUsers() ([]OrganizationUser, error) {
 		return nil, err
 	}
 	return users, nil
+}
+
+// HideOrganizationUser sets the hide field of the organization user to true.
+func (s *S) HideOrganizationUser(orgID, userID string) error {
+	result := s.db.Model(&OrganizationUser{}).
+		Where("organization_id = ?", orgID).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"hidden": true,
+		})
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // DeleteOrganizationUser deletes a organization user.

--- a/server/internal/store/orguser_test.go
+++ b/server/internal/store/orguser_test.go
@@ -52,3 +52,19 @@ func TestOrganizationUser(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
+
+func TestHideOrganizationUser(t *testing.T) {
+	s, tearDown := NewTest(t)
+	defer tearDown()
+
+	ou, err := s.CreateOrganizationUser("o1", "user1", "r1")
+	assert.NoError(t, err)
+	assert.False(t, ou.Hidden)
+
+	err = s.HideOrganizationUser("o1", "user1")
+	assert.NoError(t, err)
+
+	ou, err = s.GetOrganizationUser("o1", "user1")
+	assert.NoError(t, err)
+	assert.True(t, ou.Hidden)
+}

--- a/server/internal/store/projectuser.go
+++ b/server/internal/store/projectuser.go
@@ -14,6 +14,9 @@ type ProjectUser struct {
 	UserID         string `gorm:"uniqueIndex:user_id_project_id"`
 
 	Role string
+
+	// Hidden is set to true if the user is not visible from the list/get API call.
+	Hidden bool
 }
 
 // ToProto converts the model to Porto.
@@ -88,6 +91,24 @@ func (s *S) ListAllProjectUsers() ([]ProjectUser, error) {
 		return nil, err
 	}
 	return users, nil
+}
+
+// HideProjectUser sets the hide field of the project user to true.
+func (s *S) HideProjectUser(projectID, userID string) error {
+	result := s.db.Model(&ProjectUser{}).
+		Where("project_id = ?", projectID).
+		Where("user_id = ?", userID).
+		Updates(map[string]interface{}{
+			"hidden": true,
+		})
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // DeleteProjectUser deletes a project user.

--- a/server/internal/store/projectuser_test.go
+++ b/server/internal/store/projectuser_test.go
@@ -63,3 +63,24 @@ func TestProjectUser(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
+
+func TestHideProjectUser(t *testing.T) {
+	s, tearDown := NewTest(t)
+	defer tearDown()
+
+	pu, err := s.CreateProjectUser(CreateProjectUserParams{
+		ProjectID:      "p1",
+		OrganizationID: "o1",
+		UserID:         "user1",
+		Role:           v1.ProjectRole_PROJECT_ROLE_OWNER,
+	})
+	assert.NoError(t, err)
+	assert.False(t, pu.Hidden)
+
+	err = s.HideProjectUser("p1", "user1")
+	assert.NoError(t, err)
+
+	pu, err = s.GetProjectUser("p1", "user1")
+	assert.NoError(t, err)
+	assert.True(t, pu.Hidden)
+}


### PR DESCRIPTION
This is used to manage support account that shouldn't be visible to end users.